### PR TITLE
Catch app params is null in OnIterationStart

### DIFF
--- a/com.unity.robotics.warehouse/Scripts/Runtime/PerceptionRandomizers/FloorBoxRandomizerShim.cs
+++ b/com.unity.robotics.warehouse/Scripts/Runtime/PerceptionRandomizers/FloorBoxRandomizerShim.cs
@@ -58,9 +58,15 @@ public class FloorBoxRandomizerShim : RandomizerShim
     protected override void OnIterationStart()
     {
         if (WarehouseManager.Instance.ParentGenerated == null)
+        {
             return;
+        }
 
         // Create floor boundaries for spawning
+        if (appParam == null)
+        {
+            appParam = WarehouseManager.Instance.AppParam;
+        }
         var bounds = new Bounds(Vector3.zero, new Vector3(appParam.width, 0, appParam.length));
         placer = new SurfaceObjectPlacer(bounds, random, maxPlacementTries);
 


### PR DESCRIPTION
## Proposed change(s)

Set the value to appParam if the randomizer is called in the editor but has not been awaked yet.

### Types of change(s)

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
- [x] Ensured this PR is up-to-date with the target branch
- [ ] Added tests that prove my fix is effective or that my feature works
- [ ] Updated the [Changelog](../CHANGELOG.md) and described changes in the [Unreleased section](../CHANGELOG.md#unreleased)
- [ ] Updated the documentation as appropriate

## Other comments
