### PR TITLE
Correct the path under which the warehouse prefabs are saved

### DIFF
--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -120,7 +120,7 @@ If you would like to use the base **provided Unity project**, follow the steps d
 
 7. You can now use the warehouse environment for your simulation needs!
 
-    If desired, you can click `Save prefab` to save this version of the warehouse to `Assets/Prefabs`, fine-tune the dimensions of the warehouse, or continue to increment iterations for new randomizations.
+    If desired, you can click `Save prefab` to save this version of the warehouse to `Assets/Resources/`, fine-tune the dimensions of the warehouse, or continue to increment iterations for new randomizations.
 
 ---
 


### PR DESCRIPTION
One-liner to correct a doc instruction.
Feel free to close this and correct the plugin behavior instead of saving this to `Resources` if is not the intended behavior